### PR TITLE
Add a type=module in the script tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="description" content="Vercel SQLite ip2location demo">
   <title>Vercel SQLite ip2location demo</title>
-  <script>
+  <script type="module">
   Promise.all([
     fetch('api/country').then(b => b.json()),
     new Promise($ => addEventListener('DOMContentLoaded', $, {once: true}))
@@ -13,6 +13,9 @@
     document.querySelector('p:last-child').innerHTML =
       `Your request came from <small>(${code})</small> <strong>${name}</strong> 👋`;
   });
+  </script>
+  <script nomodule>
+    alert('You need a modern browser');
   </script>
   <style>
   body { font-family: sans-serif; }
@@ -22,6 +25,9 @@
 </head>
 <body>
   <h1><a href="https://vercel.com/">Vercel</a> SQLite ip2location demo</h1>
+  <noscript>
+    <p>You need to enable Javascript</p>
+  </noscript>
   <p>
     This site or product includes IP2Location LITE data available from
     <a href="https://lite.ip2location.com">https://lite.ip2location.com</a>.


### PR DESCRIPTION
UAs that support type=module obviously support Promises & fetch, the rest (using nomodule) can throw an alert. 
Also if javascript is disabled the noscript message will be displayed